### PR TITLE
feat: share driver card wizard state

### DIFF
--- a/admin-app/src/features/DriverCardWizard/CreateDriverCard.tsx
+++ b/admin-app/src/features/DriverCardWizard/CreateDriverCard.tsx
@@ -1,5 +1,12 @@
-const CreateDriverCard = () => {
-  return <div>Create Driver Card Step</div>;
-};
+import { useEffect } from 'react'
+import { useDriverCardWizardState } from './state'
 
-export default CreateDriverCard;
+const CreateDriverCard = () => {
+  const { reset } = useDriverCardWizardState()
+  useEffect(() => {
+    reset()
+  }, [reset])
+  return <div>Create Driver Card Step</div>
+}
+
+export default CreateDriverCard

--- a/admin-app/src/features/DriverCardWizard/DriverStep.tsx
+++ b/admin-app/src/features/DriverCardWizard/DriverStep.tsx
@@ -1,5 +1,8 @@
-const DriverStep = () => {
-  return <div>Driver Card Driver Step</div>;
-};
+import { useDriverCardWizardState } from './state'
 
-export default DriverStep;
+const DriverStep = () => {
+  const { state } = useDriverCardWizardState()
+  return <div>Driver Card Driver Step {state.activeStep}</div>
+}
+
+export default DriverStep

--- a/admin-app/src/features/DriverCardWizard/EditDriverCard.tsx
+++ b/admin-app/src/features/DriverCardWizard/EditDriverCard.tsx
@@ -1,5 +1,12 @@
-const EditDriverCard = () => {
-  return <div>Edit Driver Card Step</div>;
-};
+import { useEffect } from 'react'
+import { useDriverCardWizardState } from './state'
 
-export default EditDriverCard;
+const EditDriverCard = () => {
+  const { reset } = useDriverCardWizardState()
+  useEffect(() => {
+    reset()
+  }, [reset])
+  return <div>Edit Driver Card Step</div>
+}
+
+export default EditDriverCard

--- a/admin-app/src/features/DriverCardWizard/FacilityStep.tsx
+++ b/admin-app/src/features/DriverCardWizard/FacilityStep.tsx
@@ -1,5 +1,8 @@
-const FacilityStep = () => {
-  return <div>Driver Card Facility Step</div>;
-};
+import { useDriverCardWizardState } from './state'
 
-export default FacilityStep;
+const FacilityStep = () => {
+  const { state } = useDriverCardWizardState()
+  return <div>Driver Card Facility Step {state.activeStep}</div>
+}
+
+export default FacilityStep

--- a/admin-app/src/features/DriverCardWizard/SummaryStep.tsx
+++ b/admin-app/src/features/DriverCardWizard/SummaryStep.tsx
@@ -1,5 +1,8 @@
-const SummaryStep = () => {
-  return <div>Driver Card Summary Step</div>;
-};
+import { useDriverCardWizardState } from './state'
 
-export default SummaryStep;
+const SummaryStep = () => {
+  const { state } = useDriverCardWizardState()
+  return <div>Driver Card Summary Step {state.activeStep}</div>
+}
+
+export default SummaryStep

--- a/admin-app/src/features/DriverCardWizard/state.ts
+++ b/admin-app/src/features/DriverCardWizard/state.ts
@@ -1,0 +1,41 @@
+import { useStore } from 'react-admin'
+
+export interface DriverCardWizardState {
+  activeStep: number
+  facility: { identity_number: string }
+  facilityRecord: Record<string, unknown> | null
+  showFacilityCreate: boolean
+  driver: {
+    first_name: string
+    last_name: string
+    identity_number: string
+  }
+  driverRecord: Record<string, unknown> | null
+  showDriverCreate: boolean
+  driverCardRecord: Record<string, unknown> | null
+}
+
+const defaultState: DriverCardWizardState = {
+  activeStep: 0,
+  facility: { identity_number: '' },
+  facilityRecord: null,
+  showFacilityCreate: false,
+  driver: { first_name: '', last_name: '', identity_number: '' },
+  driverRecord: null,
+  showDriverCreate: false,
+  driverCardRecord: null,
+}
+
+export const useDriverCardWizardState = () => {
+  const [state, setState] = useStore<DriverCardWizardState>(
+    'driver-card-wizard-state',
+    defaultState
+  )
+
+  const update = (patch: Partial<DriverCardWizardState>) =>
+    setState({ ...state, ...patch })
+
+  const reset = () => setState(defaultState)
+
+  return { state, setState: update, reset }
+}


### PR DESCRIPTION
## Summary
- add DriverCardWizard store using react-admin useStore
- wire wizard components to shared store and expose reset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b6fff73808331bf675c367c4df374