### PR TITLE
refactor: relocate DriverWizard into feature module

### DIFF
--- a/admin-app/src/App.tsx
+++ b/admin-app/src/App.tsx
@@ -55,13 +55,14 @@ import {
   VehicleCreate,
   VehicleEdit,
 } from './Vehicle'
-import DriverWizard from './DriverWizard'
 import OperationCardWizard from './OperationCardWizard'
-import FacilityStep from './features/DriverCardWizard/FacilityStep'
-import DriverStep from './features/DriverCardWizard/DriverStep'
-import SummaryStep from './features/DriverCardWizard/SummaryStep'
-import CreateDriverCard from './features/DriverCardWizard/CreateDriverCard'
-import EditDriverCard from './features/DriverCardWizard/EditDriverCard'
+import DriverWizard, {
+  FacilityStep,
+  DriverStep,
+  SummaryStep,
+  CreateDriverCard,
+  EditDriverCard,
+} from './features/DriverCardWizard'
 
 // إنشاء الثيم مع دعم الاتجاه من اليمين إلى اليسار
 const theme = createTheme({

--- a/admin-app/src/features/DriverCardWizard/DriverWizard.tsx
+++ b/admin-app/src/features/DriverCardWizard/DriverWizard.tsx
@@ -19,9 +19,9 @@ import {
   required,
 } from 'react-admin'
 import { useFormContext } from 'react-hook-form'
-import LicenseTypeSelect from './components/LicenseTypeSelect'
-import CitySelect from './components/CitySelect'
-import SupplierSelect from './components/SupplierSelect'
+import LicenseTypeSelect from '../../components/LicenseTypeSelect'
+import CitySelect from '../../components/CitySelect'
+import SupplierSelect from '../../components/SupplierSelect'
 
 const DriverWizard = () => {
   const dataProvider = useDataProvider()

--- a/admin-app/src/features/DriverCardWizard/index.ts
+++ b/admin-app/src/features/DriverCardWizard/index.ts
@@ -1,0 +1,8 @@
+export { default } from './DriverWizard';
+export { default as DriverWizard } from './DriverWizard';
+export { default as CreateDriverCard } from './CreateDriverCard';
+export { default as EditDriverCard } from './EditDriverCard';
+export { default as DriverStep } from './DriverStep';
+export { default as FacilityStep } from './FacilityStep';
+export { default as SummaryStep } from './SummaryStep';
+export * from './state';

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -26,6 +26,6 @@
     - `LicenseType.tsx`: `LicenseTypeList`, `LicenseTypeShow`, `LicenseTypeForm`, `LicenseTypeCreate`, `LicenseTypeEdit` لأنواع الرخص.
     - `Supplier.tsx`: `SupplierList`, `SupplierShow`, `SupplierForm`, `SupplierCreate`, `SupplierEdit` للمزوّدين.
     - `Vehicle.tsx`: `VehicleList`, `VehicleShow`, `VehicleForm`, `VehicleCreate`, `VehicleEdit` للمركبات.
-    - `DriverWizard.tsx`: مكوّن معالج متعدد الخطوات لإنشاء منشأة، سائق، بطاقة سائق وبطاقة تشغيل.
+    - `features/DriverCardWizard/DriverWizard.tsx`: مكوّن معالج متعدد الخطوات لإنشاء منشأة، سائق، بطاقة سائق وبطاقة تشغيل.
   - ملفات الأنماط مثل `App.css` و`index.css` لتنسيق الواجهة.
 


### PR DESCRIPTION
## Summary
- move DriverWizard into src/features/DriverCardWizard
- centralize DriverCardWizard exports
- update imports after file move

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7944f9488331a6d6786dacf5747c