### PR TITLE
feat: add quick-create selects for vehicles and drivers

### DIFF
--- a/admin-app/src/OperationCardWizard.tsx
+++ b/admin-app/src/OperationCardWizard.tsx
@@ -15,8 +15,6 @@ import {
   useNotify,
   Form,
   TextInput,
-  ReferenceInput,
-  SelectInput,
   DateInput,
   NumberInput,
   required,
@@ -25,6 +23,9 @@ import { useFormContext } from 'react-hook-form'
 import LicenseTypeSelect from './components/LicenseTypeSelect'
 import CitySelect from './components/CitySelect'
 import SupplierSelect from './components/SupplierSelect'
+import ModelSelect from './components/ModelSelect'
+import ColorSelect from './components/ColorSelect'
+import DriverSelect from './components/DriverSelect'
 
 const OperationCardWizard = () => {
   const dataProvider = useDataProvider()
@@ -320,12 +321,8 @@ const OperationCardWizard = () => {
           {showVehicleCreate && (
             <Form onSubmit={handleVehicleNext}>
               <Stack spacing={2}>
-                <ReferenceInput source="model_id" reference="opc_model">
-                  <SelectInput optionText="model_name" />
-                </ReferenceInput>
-                <ReferenceInput source="color_id" reference="opc_color">
-                  <SelectInput optionText="color_name" />
-                </ReferenceInput>
+                <ModelSelect source="model_id" />
+                <ColorSelect source="color_id" />
                 <TextInput source="plate_number" />
                 <TextInput source="serial_number" />
                 <NumberInput source="manufacturing_year" />
@@ -349,9 +346,7 @@ const OperationCardWizard = () => {
         >
           <Stack spacing={2}>
             {existingCard && <TextInput source="card_number" disabled />}
-            <ReferenceInput source="driver_id" reference="opc_driver">
-              <SelectInput optionText="first_name" />
-            </ReferenceInput>
+            <DriverSelect source="driver_id" facilityId={facilityRecord?.id} />
             <LicenseTypeSelect source="card_type" />
             <SupplierSelect source="supplier_id" />
             <DateInput source="issue_date" />

--- a/admin-app/src/components/ColorSelect.tsx
+++ b/admin-app/src/components/ColorSelect.tsx
@@ -1,0 +1,68 @@
+import {
+  AutocompleteInput,
+  SimpleForm,
+  TextInput,
+  useCreateSuggestionContext,
+  useNotify,
+  required,
+  ReferenceInput,
+  Create,
+  Toolbar,
+  SaveButton,
+} from 'react-admin'
+import { Button } from '@mui/material'
+
+const ColorQuickCreateForm = () => {
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
+  const notify = useNotify()
+
+  const QuickCreateToolbar = () => (
+    <Toolbar>
+      <SaveButton />
+      <Button onClick={onCancel}>إلغاء</Button>
+    </Toolbar>
+  )
+
+  return (
+    <Create
+      resource="opc_color"
+      redirect={false}
+      mutationOptions={{
+        onSuccess: data =>
+          onCreate({ id: data.id, color_name: data.color_name }),
+        onError: error =>
+          notify(
+            (error as { message?: string })?.message ||
+              'فشل إنشاء اللون',
+            { type: 'error' }
+          ),
+      }}
+    >
+      <SimpleForm
+        defaultValues={{ color_name: filter }}
+        toolbar={<QuickCreateToolbar />}
+      >
+        <TextInput
+          source="color_name"
+          label="اسم اللون"
+          validate={required()}
+          fullWidth
+        />
+      </SimpleForm>
+    </Create>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ColorSelect = ({ source, ...props }: any) => (
+  <ReferenceInput source={source} reference="opc_color">
+    <AutocompleteInput
+      optionText="color_name"
+      create={<ColorQuickCreateForm />}
+      {...props}
+    />
+  </ReferenceInput>
+)
+
+export default ColorSelect
+

--- a/admin-app/src/components/DriverSelect.tsx
+++ b/admin-app/src/components/DriverSelect.tsx
@@ -1,0 +1,79 @@
+import {
+  AutocompleteInput,
+  SimpleForm,
+  TextInput,
+  useCreateSuggestionContext,
+  useNotify,
+  required,
+  ReferenceInput,
+  Create,
+  Toolbar,
+  SaveButton,
+} from 'react-admin'
+import { Button } from '@mui/material'
+
+interface DriverQuickCreateProps {
+  facilityId?: number
+}
+
+const DriverQuickCreateForm = ({ facilityId }: DriverQuickCreateProps) => {
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
+  const notify = useNotify()
+
+  const QuickCreateToolbar = () => (
+    <Toolbar>
+      <SaveButton />
+      <Button onClick={onCancel}>إلغاء</Button>
+    </Toolbar>
+  )
+
+  return (
+    <Create
+      resource="opc_driver"
+      redirect={false}
+      mutationOptions={{
+        onSuccess: data =>
+          onCreate({ id: data.id, first_name: data.first_name }),
+        onError: error =>
+          notify(
+            (error as { message?: string })?.message ||
+              'فشل إنشاء السائق',
+            { type: 'error' }
+          ),
+      }}
+    >
+      <SimpleForm
+        defaultValues={{ first_name: filter, facility_id: facilityId }}
+        toolbar={<QuickCreateToolbar />}
+      >
+        {!facilityId && (
+          <ReferenceInput source="facility_id" reference="opc_facility">
+            <AutocompleteInput optionText="name" validate={required()} />
+          </ReferenceInput>
+        )}
+        <TextInput
+          source="first_name"
+          label="الاسم الأول"
+          validate={required()}
+          fullWidth
+        />
+        <TextInput source="last_name" label="اسم العائلة" validate={required()} fullWidth />
+        <TextInput source="identity_number" label="رقم الهوية" fullWidth />
+      </SimpleForm>
+    </Create>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const DriverSelect = ({ source, facilityId, ...props }: any) => (
+  <ReferenceInput source={source} reference="opc_driver">
+    <AutocompleteInput
+      optionText="first_name"
+      create={<DriverQuickCreateForm facilityId={facilityId} />}
+      {...props}
+    />
+  </ReferenceInput>
+)
+
+export default DriverSelect
+

--- a/admin-app/src/components/ModelSelect.tsx
+++ b/admin-app/src/components/ModelSelect.tsx
@@ -1,0 +1,72 @@
+import {
+  AutocompleteInput,
+  SimpleForm,
+  TextInput,
+  useCreateSuggestionContext,
+  useNotify,
+  required,
+  ReferenceInput,
+  Create,
+  Toolbar,
+  SaveButton,
+  SelectInput,
+} from 'react-admin'
+import { Button } from '@mui/material'
+
+const ModelQuickCreateForm = () => {
+  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
+  const notify = useNotify()
+
+  const QuickCreateToolbar = () => (
+    <Toolbar>
+      <SaveButton />
+      <Button onClick={onCancel}>إلغاء</Button>
+    </Toolbar>
+  )
+
+  return (
+    <Create
+      resource="opc_model"
+      redirect={false}
+      mutationOptions={{
+        onSuccess: data =>
+          onCreate({ id: data.id, model_name: data.model_name }),
+        onError: error =>
+          notify(
+            (error as { message?: string })?.message ||
+              'فشل إنشاء الطراز',
+            { type: 'error' }
+          ),
+      }}
+    >
+      <SimpleForm
+        defaultValues={{ model_name: filter }}
+        toolbar={<QuickCreateToolbar />}
+      >
+        <ReferenceInput source="brand_id" reference="opc_brand">
+          <SelectInput optionText="brand_name" validate={required()} />
+        </ReferenceInput>
+        <TextInput
+          source="model_name"
+          label="اسم الطراز"
+          validate={required()}
+          fullWidth
+        />
+      </SimpleForm>
+    </Create>
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ModelSelect = ({ source, ...props }: any) => (
+  <ReferenceInput source={source} reference="opc_model">
+    <AutocompleteInput
+      optionText="model_name"
+      create={<ModelQuickCreateForm />}
+      {...props}
+    />
+  </ReferenceInput>
+)
+
+export default ModelSelect
+


### PR DESCRIPTION
## Summary
- add reusable ModelSelect, ColorSelect, DriverSelect components with quick-create dialogs
- wire OperationCardWizard to use new selects for model, color, and driver

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `psql "$PGURL" -c '\d+ opc_model'` *(fails: connection to server at "49.13.53.13" port 6543 failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b8305b4e8833193768ca7a511f358