### PR TITLE
feat: replace quick create forms with select onCreate

### DIFF
--- a/admin-app/src/components/CitySelect.tsx
+++ b/admin-app/src/components/CitySelect.tsx
@@ -1,59 +1,26 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-const CityQuickCreateForm = () => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="city"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data => onCreate(data),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message || 'فشل إنشاء المدينة',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm defaultValues={{ name_ar: filter }} toolbar={<QuickCreateToolbar />}>
-        <TextInput source="name_ar" label="اسم المدينة" validate={required()} fullWidth />
-        <TextInput source="name_en" label="الاسم بالإنجليزية" fullWidth />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CitySelect = ({ source, ...props }: any) => (
-  <ReferenceInput source={source} reference="city">
-    <AutocompleteInput
-      optionText="name_ar"
-      create={<CityQuickCreateForm />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const CitySelect = ({ source, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="city">
+      <SelectInput
+        optionText="name_ar"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('city', {
+            data: { name_ar: value },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return { id: created.id, name_ar: created.name_ar }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default CitySelect
 

--- a/admin-app/src/components/ColorSelect.tsx
+++ b/admin-app/src/components/ColorSelect.tsx
@@ -1,68 +1,26 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-const ColorQuickCreateForm = () => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="opc_color"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data =>
-          onCreate({ id: data.id, color_name: data.color_name }),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message ||
-              'فشل إنشاء اللون',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm
-        defaultValues={{ color_name: filter }}
-        toolbar={<QuickCreateToolbar />}
-      >
-        <TextInput
-          source="color_name"
-          label="اسم اللون"
-          validate={required()}
-          fullWidth
-        />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ColorSelect = ({ source, ...props }: any) => (
-  <ReferenceInput source={source} reference="opc_color">
-    <AutocompleteInput
-      optionText="color_name"
-      create={<ColorQuickCreateForm />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const ColorSelect = ({ source, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="opc_color">
+      <SelectInput
+        optionText="color_name"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('opc_color', {
+            data: { color_name: value },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return { id: created.id, color_name: created.color_name }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default ColorSelect
 

--- a/admin-app/src/components/DriverSelect.tsx
+++ b/admin-app/src/components/DriverSelect.tsx
@@ -1,79 +1,26 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-interface DriverQuickCreateProps {
-  facilityId?: number
-}
-
-const DriverQuickCreateForm = ({ facilityId }: DriverQuickCreateProps) => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="opc_driver"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data =>
-          onCreate({ id: data.id, first_name: data.first_name }),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message ||
-              'فشل إنشاء السائق',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm
-        defaultValues={{ first_name: filter, facility_id: facilityId }}
-        toolbar={<QuickCreateToolbar />}
-      >
-        {!facilityId && (
-          <ReferenceInput source="facility_id" reference="opc_facility">
-            <AutocompleteInput optionText="name" validate={required()} />
-          </ReferenceInput>
-        )}
-        <TextInput
-          source="first_name"
-          label="الاسم الأول"
-          validate={required()}
-          fullWidth
-        />
-        <TextInput source="last_name" label="اسم العائلة" validate={required()} fullWidth />
-        <TextInput source="identity_number" label="رقم الهوية" fullWidth />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const DriverSelect = ({ source, facilityId, ...props }: any) => (
-  <ReferenceInput source={source} reference="opc_driver">
-    <AutocompleteInput
-      optionText="first_name"
-      create={<DriverQuickCreateForm facilityId={facilityId} />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const DriverSelect = ({ source, facilityId, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="opc_driver">
+      <SelectInput
+        optionText="first_name"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('opc_driver', {
+            data: { first_name: value, facility_id: facilityId },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return { id: created.id, first_name: created.first_name }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default DriverSelect
 

--- a/admin-app/src/components/LicenseTypeSelect.tsx
+++ b/admin-app/src/components/LicenseTypeSelect.tsx
@@ -1,67 +1,29 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-const LicenseTypeQuickCreateForm = () => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="opc_license_type"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data => onCreate(data),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message || 'فشل إنشاء نوع الترخيص',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm
-        defaultValues={{ license_type_name_ar: filter }}
-        toolbar={<QuickCreateToolbar />}
-      >
-        <TextInput
-          source="license_type_name_ar"
-          label="نوع الترخيص"
-          validate={required()}
-          fullWidth
-        />
-        <TextInput source="license_type_name_en" label="الاسم بالإنجليزية" fullWidth />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LicenseTypeSelect = ({ source, ...props }: any) => (
-  <ReferenceInput source={source} reference="opc_license_type">
-    <AutocompleteInput
-      optionText="license_type_name_ar"
-      create={<LicenseTypeQuickCreateForm />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const LicenseTypeSelect = ({ source, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="opc_license_type">
+      <SelectInput
+        optionText="license_type_name_ar"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('opc_license_type', {
+            data: { license_type_name_ar: value },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return {
+            id: created.id,
+            license_type_name_ar: created.license_type_name_ar,
+          }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default LicenseTypeSelect
 

--- a/admin-app/src/components/ModelSelect.tsx
+++ b/admin-app/src/components/ModelSelect.tsx
@@ -1,72 +1,26 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-  SelectInput,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-const ModelQuickCreateForm = () => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="opc_model"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data =>
-          onCreate({ id: data.id, model_name: data.model_name }),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message ||
-              'فشل إنشاء الطراز',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm
-        defaultValues={{ model_name: filter }}
-        toolbar={<QuickCreateToolbar />}
-      >
-        <ReferenceInput source="brand_id" reference="opc_brand">
-          <SelectInput optionText="brand_name" validate={required()} />
-        </ReferenceInput>
-        <TextInput
-          source="model_name"
-          label="اسم الطراز"
-          validate={required()}
-          fullWidth
-        />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ModelSelect = ({ source, ...props }: any) => (
-  <ReferenceInput source={source} reference="opc_model">
-    <AutocompleteInput
-      optionText="model_name"
-      create={<ModelQuickCreateForm />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const ModelSelect = ({ source, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="opc_model">
+      <SelectInput
+        optionText="model_name"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('opc_model', {
+            data: { model_name: value },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return { id: created.id, model_name: created.model_name }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default ModelSelect
 

--- a/admin-app/src/components/SupplierSelect.tsx
+++ b/admin-app/src/components/SupplierSelect.tsx
@@ -1,58 +1,26 @@
-import {
-  AutocompleteInput,
-  SimpleForm,
-  TextInput,
-  useCreateSuggestionContext,
-  useNotify,
-  required,
-  ReferenceInput,
-  Create,
-  Toolbar,
-  SaveButton,
-} from 'react-admin'
-import { Button } from '@mui/material'
-
-const SupplierQuickCreateForm = () => {
-  const { onCancel, onCreate, filter } = useCreateSuggestionContext()
-  const notify = useNotify()
-
-  const QuickCreateToolbar = () => (
-    <Toolbar>
-      <SaveButton />
-      <Button onClick={onCancel}>إلغاء</Button>
-    </Toolbar>
-  )
-
-  return (
-    <Create
-      resource="supplier"
-      redirect={false}
-      mutationOptions={{
-        onSuccess: data => onCreate(data),
-        onError: error =>
-          notify(
-            (error as { message?: string })?.message || 'فشل إنشاء المورد',
-            { type: 'error' }
-          ),
-      }}
-    >
-      <SimpleForm defaultValues={{ name: filter }} toolbar={<QuickCreateToolbar />}>
-        <TextInput source="name" label="اسم المورد" validate={required()} fullWidth />
-      </SimpleForm>
-    </Create>
-  )
-}
+import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SupplierSelect = ({ source, ...props }: any) => (
-  <ReferenceInput source={source} reference="supplier">
-    <AutocompleteInput
-      optionText="name"
-      create={<SupplierQuickCreateForm />}
-      {...props}
-    />
-  </ReferenceInput>
-)
+const SupplierSelect = ({ source, ...props }: any) => {
+  const notify = useNotify()
+  const dataProvider = useDataProvider()
+
+  return (
+    <ReferenceInput source={source} reference="supplier">
+      <SelectInput
+        optionText="name"
+        onCreate={async value => {
+          const { data: created } = await dataProvider.create('supplier', {
+            data: { name: value },
+          })
+          notify('ra.notification.created', { type: 'info' })
+          return { id: created.id, name: created.name }
+        }}
+        {...props}
+      />
+    </ReferenceInput>
+  )
+}
 
 export default SupplierSelect
 


### PR DESCRIPTION
## Summary
- refactor city, color, model, supplier, driver and license type selects to use SelectInput with inline creation
- create new records through dataProvider and notify users on success

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b898bc6e083319b4c570710537ced