### PR TITLE
refactor: use select components

### DIFF
--- a/admin-app/src/DriverCard.tsx
+++ b/admin-app/src/DriverCard.tsx
@@ -15,6 +15,9 @@ import {
   TopToolbar,
 } from 'react-admin'
 import { useNavigate } from 'react-router-dom'
+import DriverSelect from './components/DriverSelect'
+import LicenseTypeSelect from './components/LicenseTypeSelect'
+import SupplierSelect from './components/SupplierSelect'
 
 export const DriverCardList = () => {
   const navigate = useNavigate()
@@ -77,15 +80,9 @@ export const DriverCardForm = () => (
     <ReferenceInput source="facility_id" reference="opc_facility">
       <SelectInput optionText="name" />
     </ReferenceInput>
-    <ReferenceInput source="driver_id" reference="opc_driver">
-      <SelectInput optionText="first_name" />
-    </ReferenceInput>
-    <ReferenceInput source="card_type" reference="opc_license_type">
-      <SelectInput optionText="license_type_name_ar" />
-    </ReferenceInput>
-    <ReferenceInput source="supplier_id" reference="supplier">
-      <SelectInput optionText="name" />
-    </ReferenceInput>
+    <DriverSelect source="driver_id" />
+    <LicenseTypeSelect source="card_type" />
+    <SupplierSelect source="supplier_id" />
     <DateInput source="issue_date" />
     <DateInput source="expiration_date" />
   </SimpleForm>

--- a/admin-app/src/Facility.tsx
+++ b/admin-app/src/Facility.tsx
@@ -9,10 +9,10 @@ import {
   Edit,
   SimpleForm,
   TextInput,
-  ReferenceInput,
-  SelectInput,
   DateInput,
 } from 'react-admin'
+import LicenseTypeSelect from './components/LicenseTypeSelect'
+import CitySelect from './components/CitySelect'
 
 export const FacilityList = () => (
   <List>
@@ -50,12 +50,8 @@ export const FacilityForm = () => (
     <TextInput source="name" />
     <TextInput source="english_name" />
     <TextInput source="license_number" />
-    <ReferenceInput source="license_type_id" reference="opc_license_type">
-      <SelectInput optionText="license_type_name_ar" />
-    </ReferenceInput>
-    <ReferenceInput source="license_city_id" reference="city">
-      <SelectInput optionText="name_ar" />
-    </ReferenceInput>
+    <LicenseTypeSelect source="license_type_id" />
+    <CitySelect source="license_city_id" />
     <DateInput source="license_issue_date" />
     <DateInput source="license_expiration_date" />
   </SimpleForm>

--- a/admin-app/src/OperationCard.tsx
+++ b/admin-app/src/OperationCard.tsx
@@ -15,6 +15,9 @@ import {
   TopToolbar,
 } from 'react-admin'
 import { useNavigate } from 'react-router-dom'
+import DriverSelect from './components/DriverSelect'
+import SupplierSelect from './components/SupplierSelect'
+import LicenseTypeSelect from './components/LicenseTypeSelect'
  
 export const OperationCardList = () => {
   const navigate = useNavigate()
@@ -82,18 +85,12 @@ export const OperationCardForm = () => (
     <ReferenceInput source="facility_id" reference="opc_facility">
       <SelectInput optionText="name" />
     </ReferenceInput>
-    <ReferenceInput source="driver_id" reference="opc_driver">
-      <SelectInput optionText="first_name" />
-    </ReferenceInput>
+    <DriverSelect source="driver_id" />
     <ReferenceInput source="vehicle_id" reference="opc_vehicle">
       <SelectInput optionText="plate_number" />
     </ReferenceInput>
-    <ReferenceInput source="supplier_id" reference="supplier">
-      <SelectInput optionText="name" />
-    </ReferenceInput>
-    <ReferenceInput source="card_type" reference="opc_license_type">
-      <SelectInput optionText="license_type_name_ar" />
-    </ReferenceInput>
+    <SupplierSelect source="supplier_id" />
+    <LicenseTypeSelect source="card_type" />
     <DateInput source="issue_date" />
     <DateInput source="expiration_date" />
   </SimpleForm>

--- a/admin-app/src/Vehicle.tsx
+++ b/admin-app/src/Vehicle.tsx
@@ -13,6 +13,8 @@ import {
   SelectInput,
   NumberInput,
 } from 'react-admin'
+import ModelSelect from './components/ModelSelect'
+import ColorSelect from './components/ColorSelect'
 
 export const VehicleList = () => (
   <List>
@@ -51,12 +53,8 @@ export const VehicleForm = () => (
     <ReferenceInput source="facility_id" reference="opc_facility">
       <SelectInput optionText="name" />
     </ReferenceInput>
-    <ReferenceInput source="model_id" reference="opc_model">
-      <SelectInput optionText="model_name" />
-    </ReferenceInput>
-    <ReferenceInput source="color_id" reference="opc_color">
-      <SelectInput optionText="color_name" />
-    </ReferenceInput>
+    <ModelSelect source="model_id" />
+    <ColorSelect source="color_id" />
     <TextInput source="plate_number" />
     <TextInput source="serial_number" />
     <NumberInput source="manufacturing_year" />


### PR DESCRIPTION
## Summary
- replace license type and city inputs with dedicated select components
- switch vehicle model and color fields to specialized selects
- use tailored selects for driver card and operation card references

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b8b075da08331882f7b309690faa3