### PR TITLE
Call onCreate after quick-create mutations

### DIFF
--- a/admin-app/src/components/CitySelect.tsx
+++ b/admin-app/src/components/CitySelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const CitySelect = ({ source, ...props }: any) => {
+const CitySelect = ({ source, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,11 +10,12 @@ const CitySelect = ({ source, ...props }: any) => {
       <SelectInput
         optionText="name_ar"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('city', {
+          const { data } = await dataProvider.create('city', {
             data: { name_ar: value },
           })
           notify('ra.notification.created', { type: 'info' })
-          return { id: created.id, name_ar: created.name_ar }
+          onCreate?.({ id: data.id, name_ar: data.name_ar })
+          return { id: data.id, name_ar: data.name_ar }
         }}
         {...props}
       />

--- a/admin-app/src/components/ColorSelect.tsx
+++ b/admin-app/src/components/ColorSelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ColorSelect = ({ source, ...props }: any) => {
+const ColorSelect = ({ source, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,11 +10,12 @@ const ColorSelect = ({ source, ...props }: any) => {
       <SelectInput
         optionText="color_name"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('opc_color', {
+          const { data } = await dataProvider.create('opc_color', {
             data: { color_name: value },
           })
           notify('ra.notification.created', { type: 'info' })
-          return { id: created.id, color_name: created.color_name }
+          onCreate?.({ id: data.id, color_name: data.color_name })
+          return { id: data.id, color_name: data.color_name }
         }}
         {...props}
       />

--- a/admin-app/src/components/DriverSelect.tsx
+++ b/admin-app/src/components/DriverSelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const DriverSelect = ({ source, facilityId, ...props }: any) => {
+const DriverSelect = ({ source, facilityId, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,11 +10,12 @@ const DriverSelect = ({ source, facilityId, ...props }: any) => {
       <SelectInput
         optionText="first_name"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('opc_driver', {
+          const { data } = await dataProvider.create('opc_driver', {
             data: { first_name: value, facility_id: facilityId },
           })
           notify('ra.notification.created', { type: 'info' })
-          return { id: created.id, first_name: created.first_name }
+          onCreate?.({ id: data.id, first_name: data.first_name })
+          return { id: data.id, first_name: data.first_name }
         }}
         {...props}
       />

--- a/admin-app/src/components/LicenseTypeSelect.tsx
+++ b/admin-app/src/components/LicenseTypeSelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LicenseTypeSelect = ({ source, ...props }: any) => {
+const LicenseTypeSelect = ({ source, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,13 +10,17 @@ const LicenseTypeSelect = ({ source, ...props }: any) => {
       <SelectInput
         optionText="license_type_name_ar"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('opc_license_type', {
+          const { data } = await dataProvider.create('opc_license_type', {
             data: { license_type_name_ar: value },
           })
           notify('ra.notification.created', { type: 'info' })
+          onCreate?.({
+            id: data.id,
+            license_type_name_ar: data.license_type_name_ar,
+          })
           return {
-            id: created.id,
-            license_type_name_ar: created.license_type_name_ar,
+            id: data.id,
+            license_type_name_ar: data.license_type_name_ar,
           }
         }}
         {...props}

--- a/admin-app/src/components/ModelSelect.tsx
+++ b/admin-app/src/components/ModelSelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ModelSelect = ({ source, ...props }: any) => {
+const ModelSelect = ({ source, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,11 +10,12 @@ const ModelSelect = ({ source, ...props }: any) => {
       <SelectInput
         optionText="model_name"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('opc_model', {
+          const { data } = await dataProvider.create('opc_model', {
             data: { model_name: value },
           })
           notify('ra.notification.created', { type: 'info' })
-          return { id: created.id, model_name: created.model_name }
+          onCreate?.({ id: data.id, model_name: data.model_name })
+          return { id: data.id, model_name: data.model_name }
         }}
         {...props}
       />

--- a/admin-app/src/components/SupplierSelect.tsx
+++ b/admin-app/src/components/SupplierSelect.tsx
@@ -1,7 +1,7 @@
 import { SelectInput, ReferenceInput, useNotify, useDataProvider } from 'react-admin'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SupplierSelect = ({ source, ...props }: any) => {
+const SupplierSelect = ({ source, onCreate, ...props }: any) => {
   const notify = useNotify()
   const dataProvider = useDataProvider()
 
@@ -10,11 +10,12 @@ const SupplierSelect = ({ source, ...props }: any) => {
       <SelectInput
         optionText="name"
         onCreate={async value => {
-          const { data: created } = await dataProvider.create('supplier', {
+          const { data } = await dataProvider.create('supplier', {
             data: { name: value },
           })
           notify('ra.notification.created', { type: 'info' })
-          return { id: created.id, name: created.name }
+          onCreate?.({ id: data.id, name: data.name })
+          return { id: data.id, name: data.name }
         }}
         {...props}
       />


### PR DESCRIPTION
## Summary
- forward created records to parent `onCreate` callbacks in quick-create selects for colors, suppliers, cities, models, license types, and drivers
- ensure returned fields match each input's `optionText` and `optionValue`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run check-i18n`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b8c1f46008331813c17397956f807