### PR TITLE
Add React Admin test utilities

### DIFF
--- a/admin-app/src/test-utils/index.ts
+++ b/admin-app/src/test-utils/index.ts
@@ -1,0 +1,2 @@
+export { default as mockDataProvider } from './mockDataProvider'
+export { default as renderWithAdmin } from './renderWithAdmin'

--- a/admin-app/src/test-utils/mockDataProvider.ts
+++ b/admin-app/src/test-utils/mockDataProvider.ts
@@ -1,0 +1,79 @@
+import type { DataProvider, RaRecord, Identifier } from 'react-admin'
+
+// In-memory data store seeded with users and main resources
+const data: Record<string, RaRecord[]> = {
+  users: [{ id: 1, name: 'Admin' }],
+  opc_facility: [],
+  opc_driver: [],
+  opc_driver_card: [],
+  opc_card: [],
+  opc_license_type: [],
+  opc_brand: [],
+  opc_model: [],
+  opc_color: [],
+  supplier: [],
+  city: [],
+  opc_vehicle: [],
+  audit_log: [],
+}
+
+const mockDataProvider: DataProvider = {
+  getList: async resource => ({
+    data: data[resource] ?? [],
+    total: data[resource]?.length ?? 0,
+  }),
+  getOne: async (resource, params) => ({
+    data: (data[resource] ?? []).find(record => record.id === params.id) as RaRecord,
+  }),
+  getMany: async (resource, params) => ({
+    data: (data[resource] ?? []).filter(record => params.ids.includes(record.id)),
+  }),
+  getManyReference: async (resource, params) => {
+    const records = (data[resource] ?? []).filter(
+      record => record[params.target] === params.id
+    )
+    return { data: records, total: records.length }
+  },
+  update: async (resource, params) => {
+    const records = data[resource] ?? []
+    const index = records.findIndex(record => record.id === params.id)
+    const updated = { ...records[index], ...params.data }
+    records[index] = updated
+    data[resource] = records
+    return { data: updated }
+  },
+  updateMany: async (resource, params) => {
+    const records = data[resource] ?? []
+    const ids: Identifier[] = []
+    data[resource] = records.map(record => {
+      if (params.ids.includes(record.id)) {
+        ids.push(record.id)
+        return { ...record, ...params.data }
+      }
+      return record
+    })
+    return { data: ids }
+  },
+  create: async (resource, params) => {
+    const records = data[resource] ?? []
+    const id =
+      params.data.id ?? Math.max(0, ...records.map(r => Number(r.id))) + 1
+    const record = { ...params.data, id }
+    data[resource] = [...records, record]
+    return { data: record }
+  },
+  delete: async (resource, params) => {
+    const records = data[resource] ?? []
+    const index = records.findIndex(record => record.id === params.id)
+    const [removed] = records.splice(index, 1)
+    data[resource] = records
+    return { data: removed }
+  },
+  deleteMany: async (resource, params) => {
+    const records = data[resource] ?? []
+    data[resource] = records.filter(record => !params.ids.includes(record.id))
+    return { data: params.ids }
+  },
+}
+
+export default mockDataProvider

--- a/admin-app/src/test-utils/renderWithAdmin.tsx
+++ b/admin-app/src/test-utils/renderWithAdmin.tsx
@@ -1,0 +1,9 @@
+import type { ReactElement } from 'react'
+import { render, type RenderOptions } from '@testing-library/react'
+import { Admin } from 'react-admin'
+import mockDataProvider from './mockDataProvider'
+
+const renderWithAdmin = (ui: ReactElement, options?: RenderOptions) =>
+  render(<Admin dataProvider={mockDataProvider}>{ui}</Admin>, options)
+
+export default renderWithAdmin


### PR DESCRIPTION
## Summary
- add in-memory mock data provider with CRUD support
- add renderWithAdmin helper to wrap components in Admin

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689c8d566d888331b71186485cf28a16