### PR TITLE
test: add playwright config and smoke test

### DIFF
--- a/admin-app/.gitignore
+++ b/admin-app/.gitignore
@@ -23,3 +23,7 @@ reports/
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+playwright-report/
+test-results/

--- a/admin-app/e2e/smoke.spec.ts
+++ b/admin-app/e2e/smoke.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('app loads and grid is visible', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('table')).toBeVisible();
+});

--- a/admin-app/playwright.config.ts
+++ b/admin-app/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    headless: true,
+    baseURL: 'http://127.0.0.1:5173',
+  },
+  reporter: [['junit', { outputFile: 'playwright-report/results.xml' }]],
+});

--- a/admin-app/vitest.config.ts
+++ b/admin-app/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov', 'cobertura'],
       reportsDirectory: 'reports/coverage'
-    }
+    },
+    exclude: ['e2e/**']
   }
 });


### PR DESCRIPTION
## Summary
- configure Playwright with headless mode, base URL, and JUnit reporting
- add smoke test to verify grid renders
- ignore Playwright artifacts and exclude e2e from Vitest

## Testing
- `npx playwright test --list`
- `npm test` *(fails: Vitest reports module and environment errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c94aaecac8331824404451156752d