### PR TITLE
Add codex CI workflow

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,0 +1,43 @@
+name: codex-ci
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  codex-ci:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: admin-app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test:ci
+      - name: Build
+        run: npm run build
+      - name: Run e2e tests
+        run: npm run ci:e2e
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: |
+            admin-app/reports
+            admin-app/playwright-report
+      - name: Codex fix
+        if: failure()
+        run: node tools/codex-fix.mjs


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running unit tests, build, e2e tests, artifact upload, and codex fix on failure

## Testing
- `npm ci --legacy-peer-deps`
- `npm run test:ci` *(hangs: no output)*

------
https://chatgpt.com/codex/tasks/task_e_689c98aaae648331b426a9bfc4c31d80