### PR TITLE
feat: enable mock data provider for E2E tests

### DIFF
--- a/admin-app/package.json
+++ b/admin-app/package.json
@@ -12,8 +12,8 @@
     "test": "vitest --run --reporter=verbose",
     "test:ci": "vitest --run --reporter=junit --coverage",
     "e2e": "playwright test",
-    "ci:e2e:start": "vite preview --port 5173 --strictPort",
-    "ci:e2e": "concurrently -k -s first -n PREVIEW,TEST \"npm run ci:e2e:start\" \"wait-on http://127.0.0.1:5173 && playwright test\"",
+    "ci:e2e:start": "VITE_USE_MOCK=true vite preview --port 5173 --strictPort",
+    "ci:e2e": "VITE_USE_MOCK=true concurrently -k -s first -n PREVIEW,TEST \"npm run ci:e2e:start\" \"wait-on http://127.0.0.1:5173 && playwright test\"",
     "codex:fix": "node tools/codex-fix.mjs"
   },
   "dependencies": {

--- a/admin-app/src/App.tsx
+++ b/admin-app/src/App.tsx
@@ -7,6 +7,7 @@ import { createTheme } from '@mui/material'
 import arabicMessages from './i18n/arabic'
 // استيراد موفّر البيانات المبني على Supabase
 import supabaseDataProvider from './data/supabaseDataProvider'
+import mockDataProvider from './test-utils/mockDataProvider'
 import { AuditLogList, AuditLogShow } from './AuditLog'
 
 // استيراد مكونات الموارد
@@ -75,6 +76,11 @@ const theme = createTheme({
 // تهيئة موفر الترجمة للغة العربية
 const i18nProvider = polyglotI18nProvider(() => arabicMessages, 'ar')
 
+const dataProvider =
+  import.meta.env.VITE_USE_MOCK === 'true'
+    ? mockDataProvider
+    : supabaseDataProvider()
+
 const App = () => {
   // ضبط اتجاه الصفحة ليكون من اليمين إلى اليسار عند بدء التطبيق
   useEffect(() => {
@@ -84,7 +90,7 @@ const App = () => {
   return (
     // مكوّن الإدارة مع تمرير موفّر البيانات، الثيم، وموفّر الترجمة
     <Admin
-      dataProvider={supabaseDataProvider()}
+      dataProvider={dataProvider}
       theme={theme}
       i18nProvider={i18nProvider}
     >


### PR DESCRIPTION
## Summary
- choose mock data provider when `VITE_USE_MOCK` flag is enabled
- run E2E preview with mock data provider to avoid hitting Supabase

## Testing
- `npm test` *(fails: Failed to resolve import "../maps/legacy.json" from `node_modules/entities/src/index.spec.ts`)*
- `npx vitest run src/__tests__/crud.smoke.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cce8bc388833191413144db8798ca