### PR TITLE
chore: set codex default report paths

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -40,4 +40,7 @@ jobs:
             admin-app/playwright-report
       - name: Codex fix
         if: failure()
+        env:
+          JUNIT_PATH: reports/junit/junit.xml
+          COVERAGE_PATH: reports/coverage/coverage-summary.json
         run: node tools/codex-fix.mjs

--- a/admin-app/tools/codex-fix.mjs
+++ b/admin-app/tools/codex-fix.mjs
@@ -79,8 +79,8 @@ async function createPR(owner, repo, branch, base, title, body) {
 }
 
 async function main() {
-  const junit = parseJUnit(JUNIT_PATH || 'junit.xml');
-  const coverage = parseCoverage(COVERAGE_PATH || 'coverage/coverage-summary.json');
+  const junit = parseJUnit(JUNIT_PATH || 'reports/junit/junit.xml');
+  const coverage = parseCoverage(COVERAGE_PATH || 'reports/coverage/coverage-summary.json');
 
   const failureText = junit.length
     ? junit.map(f => `- ${f.classname} ${f.name}: ${f.message}`).join('\n')


### PR DESCRIPTION
## Summary
- default codex-fix to reports/junit/junit.xml and reports/coverage/coverage-summary.json
- set JUNIT_PATH and COVERAGE_PATH envs in CI before running codex-fix

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` *(fails: url.toJSON is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf96bf048331beb264f20896c1dc