### PR TITLE
docs: display Codex CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Codex CI](https://github.com/mkatbalasd/nglonat/actions/workflows/codex-ci.yml/badge.svg)](https://github.com/mkatbalasd/nglonat/actions/workflows/codex-ci.yml)
+
 # مشروع nglonat
 
 لوحة إدارة لبطاقات السائقين والتشغيل تعتمد على React Admin وSupabase.


### PR DESCRIPTION
## Summary
- show Codex CI status badge on README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ce83a2ed8833193ee47394bd79704