### PR TITLE
test: use grid role in smoke test

### DIFF
--- a/admin-app/e2e/smoke.spec.ts
+++ b/admin-app/e2e/smoke.spec.ts
@@ -2,5 +2,6 @@ import { test, expect } from '@playwright/test';
 
 test('app loads and grid is visible', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('table')).toBeVisible();
+  const grid = page.getByRole('grid');
+  await expect(grid).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- use grid ARIA role instead of table in Playwright smoke test

## Testing
- `npx playwright test e2e/smoke.spec.ts` *(fails: Timed out 5000ms waiting for expect(locator).toBeVisible())*

------
https://chatgpt.com/codex/tasks/task_e_689cedd1b6cc8331b98d0fcacc61e7f7