### PR TITLE
Use getList params in admin mock data provider

### DIFF
--- a/admin-app/src/test-utils/mockDataProvider.ts
+++ b/admin-app/src/test-utils/mockDataProvider.ts
@@ -38,11 +38,17 @@ const db: Record<string, RaRecord[]> = {
 const mockDataProvider: DataProvider = {
   getList: async <T extends RaRecord>(
     resource: string,
-    _params: GetListParams
-  ): Promise<GetListResult<T>> => ({
-    data: (db[resource] as T[]) ?? [],
-    total: (db[resource] ?? []).length,
-  }),
+    params: GetListParams
+  ): Promise<GetListResult<T>> => {
+    const records = (db[resource] as T[]) ?? []
+    const { page, perPage } = params.pagination
+    const start = (page - 1) * perPage
+    const end = start + perPage
+    return {
+      data: records.slice(start, end),
+      total: records.length,
+    }
+  },
   getOne: async <T extends RaRecord>(
     resource: string,
     params: GetOneParams<T>


### PR DESCRIPTION
## Summary
- handle pagination params in `getList` for mock data provider

## Testing
- `cd admin-app && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d13b692ec8331990f7745da79a040