### PR TITLE
test: expand vitest config exclusions

### DIFF
--- a/admin-app/vitest.config.ts
+++ b/admin-app/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
@@ -10,6 +10,7 @@ export default defineConfig({
       reporter: ['text', 'lcov', 'cobertura'],
       reportsDirectory: 'reports/coverage'
     },
-    exclude: ['e2e/**']
+    exclude: [...defaultExclude, 'e2e/**'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}']
   }
 });


### PR DESCRIPTION
## Summary
- expand vitest exclusion list to include Vitest's defaults and e2e tests
- scope vitest to src test files

## Testing
- `npm --prefix admin-app run lint`
- `npm --prefix admin-app test`
- `cd admin-app && npx vitest`

------
https://chatgpt.com/codex/tasks/task_e_689d1a8522008331a7dafe2bbdaa2756