### PR TITLE
feat(test-utils): add safe pagination defaults

### DIFF
--- a/admin-app/src/test-utils/mockDataProvider.ts
+++ b/admin-app/src/test-utils/mockDataProvider.ts
@@ -16,6 +16,7 @@ import type {
   CreateResult,
   DeleteParams,
   DeleteResult,
+  PaginationPayload,
 } from 'react-admin'
 
 // In-memory data store seeded with users and main resources
@@ -35,13 +36,15 @@ const db: Record<string, RaRecord[]> = {
   audit_log: [],
 }
 
+const defaultPagination: PaginationPayload = { page: 1, perPage: 10 }
+
 const mockDataProvider: DataProvider = {
   getList: async <T extends RaRecord>(
     resource: string,
     params: GetListParams
   ): Promise<GetListResult<T>> => {
     const records = (db[resource] as T[]) ?? []
-    const { page, perPage } = params.pagination
+    const { page = 1, perPage = 10 } = params.pagination ?? defaultPagination
     const start = (page - 1) * perPage
     const end = start + perPage
     return {


### PR DESCRIPTION
## Summary
- ensure mock data provider safely handles missing pagination

## Testing
- `npm --prefix admin-app run lint`
- `npm --prefix admin-app test`


------
https://chatgpt.com/codex/tasks/task_e_689d1c7203508331a2d4303bb7d80703