### PR TITLE
Mock window.scrollTo in admin-app tests

### DIFF
--- a/admin-app/src/setupTests.ts
+++ b/admin-app/src/setupTests.ts
@@ -1,9 +1,18 @@
-import { afterAll, afterEach, beforeAll } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { server } from './test-utils/msw';
 
 beforeAll(() => server.listen());
+
+// محاكاة الدالة window.scrollTo لتجنب أخطاء في بيئة الاختبار
+beforeEach(() => {
+  window.scrollTo = vi.fn();
+});
+
 afterEach(() => {
+  // إعادة تعيين المحاكاة بعد كل اختبار لضمان العزل بين الاختبارات
+  (window.scrollTo as Mock).mockReset();
   server.resetHandlers();
   cleanup();
 });


### PR DESCRIPTION
## Summary
- mock `window.scrollTo` for tests and reset between runs

## Testing
- `npm --prefix admin-app run lint`
- `npm --prefix admin-app test`

------
https://chatgpt.com/codex/tasks/task_e_689d1edafcec8331a69dc4eea5490362